### PR TITLE
Add @typescript-eslint/no-import-type-side-effects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
   ],
   "rules": {
     "no-console": "warn",
+    "@typescript-eslint/no-import-type-side-effects": "error",
     "@typescript-eslint/consistent-type-imports": [
       "error",
       {


### PR DESCRIPTION
This rule is important for correctness and was not available until recently.
