### PR TITLE
Fix Created Repo Visibility

### DIFF
--- a/.github/workflows/makenew.yml
+++ b/.github/workflows/makenew.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create repository
         run: |
           gh extension install mislav/gh-repo-collab
-          gh repo create --internal --disable-wiki --description "$DESCRIPTION" $REPO
+          gh repo create --private --disable-wiki --description "$DESCRIPTION" $REPO
           gh repo edit $REPO --delete-branch-on-merge
           gh repo edit $REPO --enable-projects=false
           gh repo-collab add $REPO $CODEOWNER --permission admin


### PR DESCRIPTION
Internal repos are only available on enterprise accounts

```
GraphQL: Only organizations associated with an enterprise can set visibility to internal (createRepository)
```
